### PR TITLE
checking if post type is set

### DIFF
--- a/admin/class.yikes-woo-tabs.php
+++ b/admin/class.yikes-woo-tabs.php
@@ -40,7 +40,7 @@ if ( ! class_exists( 'YIKES_Custom_Product_Tabs_Custom_Tabs' ) ) {
 			global $post;
 			global $wp_version;
 			if ( $hook === 'post-new.php' || $hook === 'post.php' ) {
-				if ( $post->post_type === 'product' ) {
+				if ( isset( $post->post_type ) &&  $post->post_type === 'product' ) {
 
 					// Enqueue WordPress' built-in editor functions - added in WPv4.8
 					if ( function_exists( 'wp_enqueue_editor' ) ) {


### PR DESCRIPTION
Checking to see if `$post->post_type` is set before using it. Bug reported by a user on WP.org with the attached screen shot.

![bug on wp admin](https://snipboard.io/nIXxQ4.jpg)

This will make sure no errors happen within any other plugins.