### PR TITLE
Invalid argument Bug

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -1,0 +1,6 @@
+node_modules/
+.gitignore
+Gruntfile.js
+package-lock.json
+package.json
+readme.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-product-tabs",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "custom-product-tabs",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "devDependencies": {
     "grunt-cli": ">=1.3.1",
     "grunt-contrib-cssmin": ">=3.0.0",

--- a/public/class.yikes-woo-tabs-display.php
+++ b/public/class.yikes-woo-tabs-display.php
@@ -42,7 +42,7 @@ if ( ! class_exists( 'YIKES_Custom_Product_Tabs_Display' ) ) {
 
 			$product_tabs = maybe_unserialize( get_post_meta( $product_id, 'yikes_woo_products_tabs' , true ) );
 
-			if ( ! empty( $product_tabs ) ) {
+			if ( is_array( $product_tabs ) && ! empty( $product_tabs ) ) {
 
 				// Setup priorty to loop over, and render tabs in proper order
 				$i = 25; 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://yikesinc.com
 Tags: woocommerce, product tabs, repeatable, duplicate, customize, custom, tabs, product, woo, commerce
 Requires at least: 3.8
 Tested up to: 5.4
-Stable tag: 1.7.0
+Stable tag: 1.7.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,9 @@ Yes! Since v1.4 we've added the necessary code to ensure the custom tab data is 
 
 == Changelog ==
 
+= 1.7.1 – March 13th, 2020 =
+* Fixes a bug with product display in certain conditions.
+
 = 1.7.0 – March 10th, 2020 =
 * Toggle the content filter on or off setting added. Use this to help with compatibility.
 * Support WooCommerce 4.0.

--- a/readme.txt
+++ b/readme.txt
@@ -75,7 +75,7 @@ Yes! Since v1.4 we've added the necessary code to ensure the custom tab data is 
 
 == Changelog ==
 
-= 1.6.13 - January 22nd, 2020 =
+= 1.7.0 – March 10th, 2020 =
 * Toggle the content filter on or off setting added. Use this to help with compatibility.
 * Support WooCommerce 4.0.
 * Support WordPress 5.4.

--- a/yikes-inc-easy-custom-woocommerce-product-tabs.php
+++ b/yikes-inc-easy-custom-woocommerce-product-tabs.php
@@ -5,7 +5,7 @@
  * Description: Extend WooCommerce to add and manage custom product tabs. Create as many product tabs as needed per product.
  * Author: YIKES, Inc.
  * Author URI: http://www.yikesinc.com
- * Version: 1.7.0
+ * Version: 1.7.1
  * Text Domain: yikes-inc-easy-custom-woocommerce-product-tabs
  * Domain Path: languages/
  *
@@ -105,7 +105,7 @@ class YIKES_Custom_Product_Tabs {
 		 * Define the plugin's version.
 		 */
 		if ( ! defined( 'YIKES_Custom_Product_Tabs_Version' ) ) {
-			define( 'YIKES_Custom_Product_Tabs_Version', '1.7.0' );
+			define( 'YIKES_Custom_Product_Tabs_Version', '1.7.1' );
 		}
 
 		/**


### PR DESCRIPTION
Fixes: https://wordpress.org/support/topic/invalid-argument-supplied-for-foreach-143/

This bug is a type error caused by the custom meta not being "empty", as its a string, but also not being an iterable when hitting the foreach loop.

The fix was to add an additional check to make sure this was an array before using the foreach loop.